### PR TITLE
Add support for easier centralized caching

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -7,16 +7,13 @@ class InvalidCache < StandardError ; end
 
 class EuCentralBank < Money::Bank::VariableExchange
 
+  attr_accessor :last_updated
+
   ECB_RATES_URL = 'http://www.ecb.int/stats/eurofxref/eurofxref-daily.xml'
   CURRENCIES = %w(USD JPY BGN CZK DKK GBP HUF LTL LVL PLN RON SEK CHF NOK HRK RUB TRY AUD BRL CAD CNY HKD IDR INR KRW MXN MYR NZD PHP SGD THB ZAR)
 
   def update_rates(cache=nil)
-    exchange_rates(cache).each do |exchange_rate|
-      rate = exchange_rate.attribute("rate").value.to_f
-      currency = exchange_rate.attribute("currency").value
-      add_rate("EUR", currency, rate)
-    end
-    add_rate("EUR", "EUR", 1)
+    update_parsed_rates(exchange_rates(cache))
   end
 
   def save_rates(cache)
@@ -25,6 +22,14 @@ class EuCentralBank < Money::Bank::VariableExchange
       io = open(ECB_RATES_URL) ;
       io.each_line {|line| file.puts line}
     end
+  end
+
+  def update_rates_from_s(content)
+    update_parsed_rates(exchange_rates_from_s(content))
+  end
+
+  def save_rates_to_s
+    open(ECB_RATES_URL).read
   end
 
   def exchange(cents, from_currency, to_currency)
@@ -49,4 +54,18 @@ class EuCentralBank < Money::Bank::VariableExchange
     doc.xpath('gesmes:Envelope/xmlns:Cube/xmlns:Cube//xmlns:Cube')
   end
 
+  def exchange_rates_from_s(content)
+    doc = Nokogiri::XML(content)
+    doc.xpath('gesmes:Envelope/xmlns:Cube/xmlns:Cube//xmlns:Cube')
+  end
+
+  def update_parsed_rates(rates)
+    rates.each do |exchange_rate|
+      rate = exchange_rate.attribute("rate").value.to_f
+      currency = exchange_rate.attribute("currency").value
+      add_rate("EUR", currency, rate)
+    end
+    add_rate("EUR", "EUR", 1)
+    @last_updated = Time.now
+  end
 end

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -40,6 +40,26 @@ describe "EuCentralBank" do
     end
   end
 
+  it "should export to a string a valid cache that can be reread" do
+    stub(OpenURI::OpenRead).open(EuCentralBank::ECB_RATES_URL) {@cache_path}
+    s = @bank.save_rates_to_s
+    @bank.update_rates_from_s(s)
+    EuCentralBank::CURRENCIES.each do |currency|
+      @bank.get_rate("EUR", currency).should > 0
+    end
+  end
+
+  it 'should set last_updated when the rates are downloaded' do
+    lu1 = @bank.last_updated
+    @bank.update_rates(@cache_path)
+    lu2 = @bank.last_updated
+    @bank.update_rates(@cache_path)
+    lu3 = @bank.last_updated
+
+    lu1.should_not eq(lu2)
+    lu2.should_not eq(lu3)
+  end
+
   it "should return the correct exchange rates using exchange" do
     @bank.update_rates(@cache_path)
     EuCentralBank::CURRENCIES.reject{|c| %w{JPY}.include?(c) }.each do |currency|


### PR DESCRIPTION
By exposing the ability to write to and read from a string in memory directly instead of going through a file on disk, and by adding a last_updated timestamp.
