### PR TITLE
Add rates_updated_at attribute containing the date set in the XML file

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -8,12 +8,13 @@ class InvalidCache < StandardError ; end
 class EuCentralBank < Money::Bank::VariableExchange
 
   attr_accessor :last_updated
+  attr_accessor :rates_updated_at
 
   ECB_RATES_URL = 'http://www.ecb.int/stats/eurofxref/eurofxref-daily.xml'
   CURRENCIES = %w(USD JPY BGN CZK DKK GBP HUF ILS LTL LVL PLN RON SEK CHF NOK HRK RUB TRY AUD BRL CAD CNY HKD IDR INR KRW MXN MYR NZD PHP SGD THB ZAR)
 
   def update_rates(cache=nil)
-    update_parsed_rates(exchange_rates(cache))
+    update_parsed_rates(doc(cache))
   end
 
   def save_rates(cache)
@@ -25,7 +26,7 @@ class EuCentralBank < Money::Bank::VariableExchange
   end
 
   def update_rates_from_s(content)
-    update_parsed_rates(exchange_rates_from_s(content))
+    update_parsed_rates(doc_from_s(content))
   end
 
   def save_rates_to_s
@@ -48,24 +49,28 @@ class EuCentralBank < Money::Bank::VariableExchange
 
   protected
 
-  def exchange_rates(cache=nil)
+  def doc(cache)
     rates_source = !!cache ? cache : ECB_RATES_URL
-    doc = Nokogiri::XML(open(rates_source))
-    doc.xpath('gesmes:Envelope/xmlns:Cube/xmlns:Cube//xmlns:Cube')
+    Nokogiri::XML(open(rates_source))
   end
 
-  def exchange_rates_from_s(content)
-    doc = Nokogiri::XML(content)
-    doc.xpath('gesmes:Envelope/xmlns:Cube/xmlns:Cube//xmlns:Cube')
+  def doc_from_s(content)
+    Nokogiri::XML(content)
   end
 
-  def update_parsed_rates(rates)
+  def update_parsed_rates(doc)
+    rates = doc.xpath('gesmes:Envelope/xmlns:Cube/xmlns:Cube//xmlns:Cube')
+
     rates.each do |exchange_rate|
       rate = exchange_rate.attribute("rate").value.to_f
       currency = exchange_rate.attribute("currency").value
       add_rate("EUR", currency, rate)
     end
     add_rate("EUR", "EUR", 1)
+
+    rates_updated_at = doc.xpath('gesmes:Envelope/xmlns:Cube/xmlns:Cube/@time').first.value
+    @rates_updated_at = Time.parse(rates_updated_at)
+
     @last_updated = Time.now
   end
 end

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -60,6 +60,14 @@ describe "EuCentralBank" do
     lu2.should_not eq(lu3)
   end
 
+  it 'should set rates_updated_at when the rates are downloaded' do
+    lu1 = @bank.rates_updated_at
+    @bank.update_rates(@cache_path)
+    lu2 = @bank.rates_updated_at
+
+    lu1.should_not eq(lu2)
+  end
+
   it "should return the correct exchange rates using exchange" do
     @bank.update_rates(@cache_path)
     EuCentralBank::CURRENCIES.each do |currency|


### PR DESCRIPTION
Saves the modification date of the rates.

Can be used for a cache expiry implementation like so:

```
@bank = EuCentralBank.new

cache = "tmp/ecb_exchange_rates.xml"

begin
  @bank.update_rates(cache)
rescue
end

if !@bank.rates_updated_at || @bank.rates_updated_at < Time.now - 1.days
  @bank.update_rates
  @bank.save_rates(cache)
end
```
