### PR TITLE
Add the Nokogiri::XML::XPath::SyntaxError exception handle.

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -51,7 +51,9 @@ class EuCentralBank < Money::Bank::VariableExchange
 
   def doc(cache)
     rates_source = !!cache ? cache : ECB_RATES_URL
-    Nokogiri::XML(open(rates_source))
+    Nokogiri::XML(open(rates_source)).tap {|doc| doc.xpath('gesmes:Envelope/xmlns:Cube/xmlns:Cube//xmlns:Cube') }
+  rescue Nokogiri::XML::XPath::SyntaxError
+    Nokogiri::XML(open(ECB_RATES_URL))
   end
 
   def doc_from_s(content)

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -5,6 +5,7 @@ describe "EuCentralBank" do
   before(:each) do
     @bank = EuCentralBank.new
     @cache_path = File.expand_path(File.dirname(__FILE__) + '/exchange_rates.xml')
+    @illegal_cahce_path = File.expand_path(File.dirname(__FILE__) + '/illegal_exchange_rates.xml')
     @yml_cache_path = File.expand_path(File.dirname(__FILE__) + '/exchange_rates.yml')
     @tmp_cache_path = File.expand_path(File.dirname(__FILE__) + '/tmp/exchange_rates.xml')
     @exchange_rates = YAML.load_file(@yml_cache_path)
@@ -28,6 +29,14 @@ describe "EuCentralBank" do
   it "should update itself with exchange rates from ecb website" do
     stub(OpenURI::OpenRead).open(EuCentralBank::ECB_RATES_URL) {@cache_path}
     @bank.update_rates
+    EuCentralBank::CURRENCIES.each do |currency|
+      @bank.get_rate("EUR", currency).should > 0
+    end
+  end
+
+  it "should update itself with exchange rates from ecb website when the data get from cache is illegal" do
+    stub(OpenURI::OpenRead).open(EuCentralBank::ECB_RATES_URL) {@cache_path}
+    @bank.update_rates(@illegal_cahce_path)
     EuCentralBank::CURRENCIES.each do |currency|
       @bank.get_rate("EUR", currency).should > 0
     end

--- a/spec/illegal_exchange_rates.xml
+++ b/spec/illegal_exchange_rates.xml
@@ -1,0 +1,7 @@
+<html>
+<head>
+  <title>Illegal xml file</title>
+</head>
+</body>
+</html>
+


### PR DESCRIPTION
Sometime we will get the Nokogiri::XML::XPath::SyntaxError, let's try get it from ecb website again.
