### PR TITLE
update money dependency to 6.0.1

### DIFF
--- a/eu_central_bank.gemspec
+++ b/eu_central_bank.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "nokogiri"
-  s.add_dependency "money",    "= 6.0.1.beta3"
+  s.add_dependency "money", ">= 6.0.1"
 
   s.add_development_dependency "rspec", ">= 2.0.0"
   s.add_development_dependency "rr"


### PR DESCRIPTION
I thought this was worth it since the money 6.0.1 is out of beta. I wasn't entirely sure if using `>=` or `~>` was preferable. money-rails seems to use `~>` but it looks like this gem has historically favored `>=`.

Maybe a good time to release an updated gem, to get it on money 6.0 like the other gems?
