### PR TITLE
Allow bumps in minor version from dependent gems

### DIFF
--- a/eu_central_bank.gemspec
+++ b/eu_central_bank.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |s|
   s.summary      = "Calculates exchange rates based on rates from european central bank. Money gem compatible."
   s.description  = "This gem reads exchange rates from the european central bank website. It uses it to calculates exchange rates. It is compatible with the money gem"
 
-  s.add_dependency "nokogiri", "~> 1.6.3"
-  s.add_dependency "money", "~> 6.5.0"
+  s.add_dependency "nokogiri", "~> 1.6", ">= 1.6.3"
+  s.add_dependency "money", "~> 6.5"
 
-  s.add_development_dependency "rspec", "~> 3.3.0"
+  s.add_development_dependency "rspec", "~> 3.3"
 
   s.files         = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md)
   s.require_path = "lib"


### PR DESCRIPTION
I've made a very small change to the `gemspec` which makes this gem compatible with the latest version of RubyMoney (and any future versions which are compatible with the [SemVer](http://semver.org/) versioning used).