### PR TITLE
Update eu_central_bank.gemspec

### DIFF
--- a/eu_central_bank.gemspec
+++ b/eu_central_bank.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description  = "This gem reads exchange rates from the european central bank website. It uses it to calculates exchange rates. It is compatible with the money gem"
 
   s.add_dependency "nokogiri", "~> 1.6.3"
-  s.add_dependency "money", "~> 6.5.0"
+  s.add_dependency "money", "~> 6.6.0"
 
   s.add_development_dependency "rspec", "~> 3.3.0"
 


### PR DESCRIPTION
Keeping it compatible with money-rails, which already refers to money 6.6