### PR TITLE
Bug when calculating rate from historical base rates

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -69,12 +69,16 @@ class EuCentralBank < Money::Bank::VariableExchange
   end
 
   def get_rate(from, to, date = nil)
+    return 1 if from == to
+
     check_currency_available(from)
     check_currency_available(to)
+
     if date.is_a?(Hash)
       # Backwards compatibility for the opts hash
       date = date[:date]
     end
+
     store.get_rate(::Money::Currency.wrap(from).iso_code, ::Money::Currency.wrap(to).iso_code, date)
   end
 

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -206,4 +206,18 @@ describe "EuCentralBank" do
     expect { @bank.get_rate("ARG","CLP")}.to raise_exception(CurrencyUnavailable)
     expect { @bank.get_rate("CLP","ARG")}.to raise_exception(CurrencyUnavailable)
   end
+
+  it "should return 1 for equivilent rates" do
+    expect(@bank.get_rate('EUR', 'EUR')).to eq(1)
+    expect(@bank.get_rate('AUD', 'AUD')).to eq(1)
+  end
+
+  it "should not fail when calculating rate from historical base rates" do
+    @bank.update_historical_rates
+
+    expect {
+      @bank.exchange(100, 'GBP', 'EUR', Date.today - 7)
+    }.not_to raise_error
+  end
 end
+


### PR DESCRIPTION
When calculating historical conversion using `from_base_rate/to_base_rate` we would often request something like `get_rate("EUR", "EUR", date)`, which would result in us receiving a `nil` from the store.

The simplest way around this was to make sure that `get_rate` would return 1 whenever it is passed equivalent rates.

---

Also, I think this could solve the occasional `NoMethodError: undefined method `/' for nil:NilClass` issues folks were having https://github.com/RubyMoney/eu_central_bank/issues/47. This is how the issue was manifesting for me.