### PR TITLE
Raise error in case of missing exchange rate

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -63,6 +63,14 @@ class EuCentralBank < Money::Bank::VariableExchange
         from_base_rate = get_rate("EUR", from.currency.to_s, date)
         to_base_rate = get_rate("EUR", to_currency, date)
       end
+
+      unless from_base_rate && to_base_rate
+        message = "No conversion rate known for '#{from.currency.iso_code}' -> '#{to_currency}'"
+        message << " on #{date.to_s}" if date
+
+        raise Money::Bank::UnknownRate, message
+      end
+
       rate = to_base_rate / from_base_rate
     end
 

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -116,15 +116,34 @@ describe "EuCentralBank" do
     end
   end
 
-  it "should return the correct exchange rates using exchange_with" do
-    @bank.update_rates(@cache_path)
-    EuCentralBank::CURRENCIES.each do |currency|
-      subunit_to_unit  = Money::Currency.wrap(currency).subunit_to_unit
-      amount_from_rate = (@exchange_rates["currencies"][currency] * subunit_to_unit).round(0).to_i
+  describe '#exchange_with' do
+    let(:money) { Money.new(100, 'EUR') }
 
-      expect(@bank.exchange_with(Money.new(100, "EUR"), currency).cents).to eq(amount_from_rate)
+    it 'should return the correct exchange rates using exchange_with' do
+      @bank.update_rates(@cache_path)
+      EuCentralBank::CURRENCIES.each do |currency|
+        subunit_to_unit  = Money::Currency.wrap(currency).subunit_to_unit
+        amount_from_rate = (@exchange_rates["currencies"][currency] * subunit_to_unit).round(0).to_i
+
+        expect(@bank.exchange_with(Money.new(100, "EUR"), currency).cents).to eq(amount_from_rate)
+      end
+    end
+
+    it 'raises Money::Bank::UnknownRate if rates are not available' do
+      expect do
+        @bank.exchange_with(money, 'USD')
+      end.to raise_error(Money::Bank::UnknownRate, "No conversion rate known for 'EUR' -> 'USD'")
+    end
+
+    it 'raises Money::Bank::UnknownRate if rates for a specific date are not available' do
+      ['2017-02-22', Date.new(2017, 2, 22)].each do |date|
+        expect do
+          @bank.exchange_with(money, 'USD', date)
+        end.to raise_error(Money::Bank::UnknownRate, "No conversion rate known for 'EUR' -> 'USD' on 2017-02-22")
+      end
     end
   end
+
 
   it "should return the correct exchange rates using historical exchange" do
     yml_path = File.expand_path(File.dirname(__FILE__) + '/historical_exchange_rates.yml')


### PR DESCRIPTION
Instead of very unhelpful `NoMethodError` this will raise a proper `Money::Bank::UnknownRate` when missing exchange rate from the store