### PR TITLE
fix(EuCentralBankHistoricalDataSupport) @mutex

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -17,8 +17,8 @@ class EuCentralBank < Money::Bank::VariableExchange
   SERIALIZER_DATE_SEPARATOR = '_AT_'
 
   CURRENCIES = %w(USD JPY BGN CZK DKK GBP HUF ILS PLN RON SEK CHF NOK HRK RUB TRY AUD BRL CAD CNY HKD IDR INR KRW MXN MYR NZD PHP SGD THB ZAR).map(&:freeze).freeze
-  ECB_RATES_URL = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml'.freeze
-  ECB_90_DAY_URL = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml'.freeze
+  ECB_RATES_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml'.freeze
+  ECB_90_DAY_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml'.freeze
 
   def initialize(*)
     super

--- a/lib/money/rates_store/eu_central_bank_historical_data_support.rb
+++ b/lib/money/rates_store/eu_central_bank_historical_data_support.rb
@@ -20,7 +20,7 @@ module Money::RatesStore
         # locking within the same thread.
         force_sync = false
       end
-      if !force_sync && (@in_transaction || options[:without_mutex])
+      if !@mutex.respond_to?(:synchronize) || (!force_sync && (@in_transaction))
         block.call self
       else
         @mutex.synchronize do


### PR DESCRIPTION
do not @mutex.synchronize unless it responds to that message.

I'm not entirely sure if this change is in align with the original intention of this part of the code.