### PR TITLE
Use HTTPS when requesting exchange rate XML

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -17,8 +17,8 @@ class EuCentralBank < Money::Bank::VariableExchange
   SERIALIZER_DATE_SEPARATOR = '_AT_'
 
   CURRENCIES = %w(USD JPY BGN CZK DKK GBP HUF ILS ISK PLN RON SEK CHF NOK HRK RUB TRY AUD BRL CAD CNY HKD IDR INR KRW MXN MYR NZD PHP SGD THB ZAR).map(&:freeze).freeze
-  ECB_RATES_URL = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml'.freeze
-  ECB_90_DAY_URL = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml'.freeze
+  ECB_RATES_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml'.freeze
+  ECB_90_DAY_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml'.freeze
 
   def initialize(st = Money::RatesStore::StoreWithHistoricalDataSupport.new, &block)
     super


### PR DESCRIPTION
It appears that the www.ecb.europa.eu domain now force-redirects to HTTPS, and that is causing an issue. See below:

```
rake aborted!
redirection forbidden: http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml -> https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
/app/vendor/bundle/ruby/2.3.0/gems/eu_central_bank-1.3.0/lib/eu_central_bank.rb:166:in `doc'
/app/vendor/bundle/ruby/2.3.0/gems/eu_central_bank-1.3.0/lib/eu_central_bank.rb:29:in `update_rates'
/app/config/initializers/money.rb:11:in `<top (required)>'
```
This PR updates the constants to use HTTPS to fetch the exchange rate data.
