### PR TITLE
Updated ECB urls that were switched to https

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -17,8 +17,8 @@ class EuCentralBank < Money::Bank::VariableExchange
   SERIALIZER_DATE_SEPARATOR = '_AT_'
 
   CURRENCIES = %w(USD JPY BGN CZK DKK GBP HUF ILS ISK PLN RON SEK CHF NOK HRK RUB TRY AUD BRL CAD CNY HKD IDR INR KRW MXN MYR NZD PHP SGD THB ZAR).map(&:freeze).freeze
-  ECB_RATES_URL = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml'.freeze
-  ECB_90_DAY_URL = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml'.freeze
+  ECB_RATES_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml'.freeze
+  ECB_90_DAY_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml'.freeze
 
   def initialize(st = Money::RatesStore::StoreWithHistoricalDataSupport.new, &block)
     super


### PR DESCRIPTION
Hi there!

The EU Central Bank changed their exchange rates XML URLs from http to https. This had happened just a few hours ago. After that the gem's functionality stopped working throwing the following exception: "redirection forbidden: http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml -> https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml". We've quickly noticed that and made a fork with the updated urls to make the exchange work again. Surely, it needs to be updated in the original repository.

Best regards,
Buru