### PR TITLE
Allow more recent versions of Nokogiri

### DIFF
--- a/eu_central_bank.gemspec
+++ b/eu_central_bank.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary      = "Calculates exchange rates based on rates from european central bank. Money gem compatible."
   s.description  = "This gem reads exchange rates from the european central bank website. It uses it to calculates exchange rates. It is compatible with the money gem"
 
-  s.add_dependency "nokogiri", RUBY_VERSION >= "2.1" ? "~> 1.8.1" : "~> 1.6.8"
+  s.add_dependency "nokogiri", RUBY_VERSION >= "2.1" ? "~> 1.8" : "~> 1.6.8"
   s.add_dependency "money", "~> 6.13"
 
   s.add_development_dependency "rspec", "~> 3.5.0"


### PR DESCRIPTION
It would be great to be able to use more recent versions of Nokogiri, specifically ones that are compatible with the new Ruby 2.6 release :)