### PR TITLE
Use thread-safety provided by the superclass in StoreWithHistoricalDataSupport

### DIFF
--- a/eu_central_bank.gemspec
+++ b/eu_central_bank.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license      = "MIT"
 
   s.add_dependency "nokogiri", RUBY_VERSION >= "2.1" ? "~> 1.9" : "~> 1.6.8"
-  s.add_dependency "money", "~> 6.13"
+  s.add_dependency "money", "~> 6.13", ">= 6.13.6"
 
   s.add_development_dependency "rspec", "~> 3.5.0"
 

--- a/lib/money/rates_store/store_with_historical_data_support.rb
+++ b/lib/money/rates_store/store_with_historical_data_support.rb
@@ -3,33 +3,16 @@ module Money::RatesStore
     INDEX_DATE_SEPARATOR = '_AT_'.freeze
 
     def add_rate(currency_iso_from, currency_iso_to, rate, date = nil)
-      transaction { index[rate_key_for(currency_iso_from, currency_iso_to, date)] = rate }
+      transaction { rates[rate_key_for(currency_iso_from, currency_iso_to, date)] = rate }
     end
 
     def get_rate(currency_iso_from, currency_iso_to, date = nil)
-      transaction { index[rate_key_for(currency_iso_from, currency_iso_to, date)] }
+      transaction { rates[rate_key_for(currency_iso_from, currency_iso_to, date)] }
     end
 
     # Wraps block execution in a thread-safe transaction
-    def transaction(force_sync = false, &block)
-      # Ruby 1.9.3 does not support @mutex.owned?
-      if @mutex.respond_to?(:owned?)
-        force_sync = false if @mutex.locked? && @mutex.owned?
-      else
-        # If we allowed this in Ruby 1.9.3, it might possibly cause recursive
-        # locking within the same thread.
-        force_sync = false
-      end
-      if !force_sync && (@in_transaction || options[:without_mutex])
-        block.call self
-      else
-        @mutex.synchronize do
-          @in_transaction = true
-          result = block.call
-          @in_transaction = false
-          result
-        end
-      end
+    def transaction(_force_sync = false, &block)
+      super &block
     end
 
     # Iterate over rate tuples (iso_from, iso_to, rate)
@@ -47,7 +30,7 @@ module Money::RatesStore
     #   end
     def each_rate(&block)
       enum = Enumerator.new do |yielder|
-        index.each do |key, rate|
+        rates.each do |key, rate|
           iso_from, iso_to = key.split(Memory::INDEX_KEY_SEPARATOR)
           iso_to, date = iso_to.split(INDEX_DATE_SEPARATOR)
           date = Date.parse(date) if date
@@ -60,10 +43,10 @@ module Money::RatesStore
 
     private
 
-      def rate_key_for(currency_iso_from, currency_iso_to, date = nil)
-        key = [currency_iso_from, currency_iso_to].join(Memory::INDEX_KEY_SEPARATOR)
-        key = [key, date.to_s].join(INDEX_DATE_SEPARATOR) if date
-        key.upcase
-      end
+    def rate_key_for(currency_iso_from, currency_iso_to, date = nil)
+      key = [currency_iso_from, currency_iso_to].join(Memory::INDEX_KEY_SEPARATOR)
+      key = [key, date.to_s].join(INDEX_DATE_SEPARATOR) if date
+      key.upcase
+    end
   end
 end

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -195,21 +195,21 @@ describe "EuCentralBank" do
       raw_rates = @bank.export_rates(:json)
       other_bank.import_rates(:json, raw_rates)
 
-      expect(@bank.store.send(:index)).to eq(other_bank.store.send(:index))
+      expect(@bank.store.send(:rates)).to eq(other_bank.store.send(:rates))
     end
 
     it 're-imports Marshalled ruby' do
       raw_rates = @bank.export_rates(:ruby)
       other_bank.import_rates(:ruby, raw_rates)
 
-      expect(@bank.store.send(:index)).to eq(other_bank.store.send(:index))
+      expect(@bank.store.send(:rates)).to eq(other_bank.store.send(:rates))
     end
 
     it 're-imports YAML' do
       raw_rates = @bank.export_rates(:yaml)
       other_bank.import_rates(:yaml, raw_rates)
 
-      expect(@bank.store.send(:index)).to eq(other_bank.store.send(:index))
+      expect(@bank.store.send(:rates)).to eq(other_bank.store.send(:rates))
     end
   end
 


### PR DESCRIPTION
Money 6.13.5 has introduced breaking changes to an implicit private interface that this gem depended on. This PR should fix it.

Also this PR removes a non-thread-safe implementation of `transaction` in favour of the superclass implementation. `force_sync` argument and `options[:without_mutex]` are now obsolete.

Should fix https://github.com/RubyMoney/money/issues/900 and https://github.com/RubyMoney/eu_central_bank/issues/101