### PR TITLE
issue #109 allow a fallback when loading cached rate files via update…

### DIFF
--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -25,8 +25,8 @@ class EuCentralBank < Money::Bank::VariableExchange
     @currency_string = nil
   end
 
-  def update_rates(cache=nil)
-    update_parsed_rates(doc(cache))
+  def update_rates(cache=nil, url=ECB_RATES_URL)
+    update_parsed_rates(doc(cache, url))
   end
 
   def update_historical_rates(cache=nil)


### PR DESCRIPTION
per #109, support a way of controlling the fallback behavior when a cache file fails to load