### PR TITLE
Move the Croatian kuna (HRK) and Russian ruble (RUB) to legacy currencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # eu_central_bank changelog
 
+* Move Croatian Kuna (HRK) and Russian Ruble (RUB) to legacy currencies
+
 ## 1.7.0 (Nov 17 2021)
 
 * Support historical rates

--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -17,12 +17,12 @@ class EuCentralBank < Money::Bank::VariableExchange
 
   SERIALIZER_DATE_SEPARATOR = '_AT_'
   DECIMAL_PRECISION = 5
-  CURRENCIES = %w(USD JPY BGN CZK DKK GBP HUF ILS ISK PLN RON SEK CHF NOK HRK RUB TRY AUD BRL CAD CNY HKD IDR INR KRW MXN MYR NZD PHP SGD THB ZAR).map(&:freeze).freeze
+  CURRENCIES = %w(USD JPY BGN CZK DKK GBP HUF ILS ISK PLN RON SEK CHF NOK TRY AUD BRL CAD CNY HKD IDR INR KRW MXN MYR NZD PHP SGD THB ZAR).map(&:freeze).freeze
   ECB_RATES_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml'.freeze
   ECB_90_DAY_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml'.freeze
   ECB_ALL_HIST_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml'.freeze
 
-  LEGACY_CURRENCIES = %w(CYP SIT ROL TRL)
+  LEGACY_CURRENCIES = %w(CYP HRK RUB SIT ROL TRL)
 
   def initialize(st = Money::RatesStore::StoreWithHistoricalDataSupport.new, &block)
     super

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -176,7 +176,7 @@ describe "EuCentralBank" do
       rates = YAML.load(@bank.export_rates(:yaml))
       rates.delete('EUR_TO_EUR')
       rates = rates.values.collect(&:to_i)
-      expect(rates.length).to eq(34)
+      expect(rates.length).to eq(32)
       expect(rates).to satisfy { |rts|
         rts.all?(&:even?) or rts.all?(&:odd?)
       }


### PR DESCRIPTION
The Croatian kuna was retired at the end of 2022.  And there is currently no exchange between EUR and RUB.  So these need to be moved to legacy currencies.

Making this change makes CI run green on my fork (CI is currently failing on main).

